### PR TITLE
Integration with php5.5

### DIFF
--- a/SchoologyApi.class.php
+++ b/SchoologyApi.class.php
@@ -477,7 +477,7 @@ class SchoologyApi
     foreach( $fields as $field ) {
       if( preg_match('/([^:]+): (.+)/m', $field, $match) ) {
         $callback = function($tmp){ 
-            return strtoupper("\0"); 
+            return strtoupper($tmp[0]); 
         };
         $match[1] = preg_replace_callback('/(?<=^|[\x09\x20\x2D])./', 
                 $callback,


### PR DESCRIPTION
I tested your SDK on apache server with php version 5.5 and I saw "Deprecated: preg_replace(): The /e modifier is deprecated, use preg_replace_callback" error. You can read about that here http://php.net/manual/en/migration55.deprecated.php.

I changed your SDK. You can check now.
